### PR TITLE
Add parameterization for the mapping between METS and hOCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Options:
   -o, --out-dir PATH         Existing directory for storing the updated OCR
                              files [required]
   -O, --order-file FILENAME  Destination for file order information
+  -m, --mapping FILENAME     METS to hOCR structural types mapping
   --help                     Show this message and exit.
 ```
 The METS file bundles all information on `tocrify`'s input, namely the `hOCR` files which have to be referenced in dedicated file groups (`fileGrp[@USE='FULLTEXT HOCR']`). With the help of the parameter `-o`, the output directory for the updated `hOCR` files can be specified. If given the parameter `-O`, `tocrify` writes the physical order of the `hOCR` files (which is not necessarily equal to their alphanumeric order) to the specified destination.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click
 lxml
 python-Levenshtein
+pyyaml

--- a/tocrify/__init__.py
+++ b/tocrify/__init__.py
@@ -1,2 +1,3 @@
 from tocrify.api import Mets
 from tocrify.api import Hocr
+from tocrify.api import Mets2hocr

--- a/tocrify/api/__init__.py
+++ b/tocrify/api/__init__.py
@@ -1,2 +1,3 @@
 from .mets import Mets
 from .hocr import Hocr
+from .hocr import Mets2hocr

--- a/tocrify/data/mets2hocr.yml
+++ b/tocrify/data/mets2hocr.yml
@@ -1,0 +1,37 @@
+chapter:
+    0: "ocr_chapter"
+    1: "ocr_section"
+    2: "ocr_subsection"
+    3: "ocr_subsubsection"
+section:
+    0: "ocr_chapter"
+    1: "ocr_section"
+    2: "ocr_subsection"
+    3: "ocr_subsubsection"
+title_page:
+    0: "ocr_title_page"
+    1: ""
+contents:
+    0: "ocr_contents"
+    1: "ocr_contents"
+preface:
+    0: "ocr_preface"
+    1: "ocr_preface"
+index:
+    0: "ocr_index"
+    1: "ocr_index"
+illustration:
+    0: "ocr_illustration"
+    1: "ocr_illustration"
+dedication:
+    0: "ocr_dedication"
+    1: "ocr_dedication"
+map:
+    0: "ocr_map"
+    1: "ocr_map"
+additional:
+    0: "ocr_additional"
+    1: "ocr_additional"
+spine:
+    0: ""
+    1: ""


### PR DESCRIPTION
Realized as a dedicated class which is spurred using a YAML file
which maybe set via CLI parameter. A default
(`tocrify/data/mets2hocr.yml`) is given and used. Invocation does
not necessarily change consequently.

Fixes https://github.com/deutschestextarchiv/tocrify/issues/15