### PR TITLE
Fix identification of title element

### DIFF
--- a/tocrify/api/mets.py
+++ b/tocrify/api/mets.py
@@ -37,6 +37,9 @@ class Physical:
         The constructor.
         """
         self.phys_id = node.get("ID")
+        # addressed ID formats:
+        # HOCR+ID (e.g. 'HOCR1856940')
+        # ID+HOCR (e.g. 'FILE_0010_FULLTEXT_HOCR')
         self.hocr_id = node.xpath("./mets:fptr[contains(@FILEID, \"HOCR\")]", namespaces=ns)[0].get("FILEID")
 
 class FileHocr:
@@ -135,7 +138,7 @@ class Mets:
                 else:
                     stack.append(iter(e))
                     # skip the title element (has ADMID)
-                    if (e.tag == METS + "div") and e.get("ADMID") == None:
+                    if (e.tag == METS + "div") and not e.get("ADMID"):
                         yield (Logical(e, stack.__len__() - skipped - 1))
                     else:
                         skipped += 1

--- a/tocrify/api/mets.py
+++ b/tocrify/api/mets.py
@@ -37,7 +37,7 @@ class Physical:
         The constructor.
         """
         self.phys_id = node.get("ID")
-        self.hocr_id = node.xpath("./mets:fptr[starts-with(@FILEID, \"HOCR\")]", namespaces=ns)[0].get("FILEID")
+        self.hocr_id = node.xpath("./mets:fptr[contains(@FILEID, \"HOCR\")]", namespaces=ns)[0].get("FILEID")
 
 class FileHocr:
     """
@@ -134,8 +134,8 @@ class Mets:
                     stack.pop()
                 else:
                     stack.append(iter(e))
-                    # skip the title element (has DMDID)
-                    if (e.tag == METS + "div") and e.get("DMDID") == None:
+                    # skip the title element (has ADMID)
+                    if (e.tag == METS + "div") and e.get("ADMID") == None:
                         yield (Logical(e, stack.__len__() - skipped - 1))
                     else:
                         skipped += 1

--- a/tocrify/data/mets2hocr.yml
+++ b/tocrify/data/mets2hocr.yml
@@ -22,6 +22,9 @@ title_page:
 contents:
     0: "ocr_contents"
     1: "ocr_contents"
+introduction:
+    0: "ocr_chapter"
+    1: "ocr_chapter"
 preface:
     0: "ocr_preface"
     1: "ocr_preface"
@@ -40,6 +43,9 @@ map:
 additional:
     0: "ocr_additional"
     1: "ocr_additional"
+advertising:
+    0: "ocr_advertising"
+    1: "ocr_advertising"
 spine:
     0: ""
     1: ""

--- a/tocrify/scripts/tocrify.py
+++ b/tocrify/scripts/tocrify.py
@@ -18,7 +18,6 @@ from tocrify import Mets2hocr
 def cli(mets,out_dir,order_file, mapping):
     """ METS: Input METS XML """
     
-    click.echo("%s" % out_dir, err=True)
     mwd = os.path.abspath(os.path.dirname(mets.name))
 
     #


### PR DESCRIPTION
Previously, `div`s in  METS' logical struct map have been tested
for `DMDID` which in the DSDK data is only present in title elements.
Testing with METS from the SLUB revealed that `DMDID` may well be
present in "real" structure elements. Therefore the test has been
modified to check for `ADMID` which in both collections is realted
to the title element.