### PR TITLE
Fix length computation for label matching

### DIFF
--- a/tocrify/api/hocr.py
+++ b/tocrify/api/hocr.py
@@ -215,7 +215,7 @@ class Hocr:
             # all lines which contribute to the matching window are collected
             # to deal with multi-line labels
             if begin != -1:
-                end = begin + len(logical.label) - 1
+                end = begin + len(logical.label)
                 cmp_lines = []
                 pars = []
                 for l in range(0, end - begin):


### PR DESCRIPTION
Labels of length one were not correctly matched onto the text.
In fact, they could not be matched. The -1 cut (which was
responsible for that) has been removed.

Fixes #19 