### PR TITLE
Add default METS to hOCR mapping to installed files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import os
-
 from setuptools import setup, find_packages
-from pkg_resources import resource_filename, Requirement
 
 with open('README.md') as f:
     readme = f.read()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
+import os
+
 from setuptools import setup, find_packages
+from pkg_resources import resource_filename, Requirement
 
 with open('README.md') as f:
     readme = f.read()
@@ -17,6 +20,7 @@ setup(
     author_email='wuerzner@bbaw.de, boenig@bbaw.de',
     license=license,
     packages=find_packages(exclude=('tests', 'docs')),
+    package_data={'tocrify' : ['data/mets2hocr.yml']},
     install_requires=[
     ],
     entry_points={


### PR DESCRIPTION
It was not installed before but is now (via `package_data`).