### PR TITLE
Add rescue placement for headings of length 1

### DIFF
--- a/tocrify/api/hocr.py
+++ b/tocrify/api/hocr.py
@@ -240,6 +240,7 @@ class Hocr:
             # all lines which contribute to the matching window are collected
             # to deal with multi-line labels
             if begin != -1:
+                # FIXME: this way, we cannot handle matches of length 1
                 end = begin + length - 1
                 cmp_lines = []
                 pars = []
@@ -266,7 +267,7 @@ class Hocr:
                             if len(par) == 0:
                                 par.getparent().remove(par)
 
-                if len(pars[0]) == len(cmp_lines):
+                if pars and len(pars[0]) == len(cmp_lines):
                     # replace paragraph elment with hOCR element representation
                     if pars[0].tag == XHTML + "p":
                         pars[0].tag = XHTML + "h%i" % (logical.depth + 1)
@@ -280,7 +281,7 @@ class Hocr:
                         pars[0].getparent().insert(pars[0].getparent().index(pars[0]) + 1, new_h)
                     ingested = True
                 # par has to be split!
-                elif len(pars[0]) > len(cmp_lines):
+                elif pars and len(pars[0]) > len(cmp_lines):
                     # iterate over lines and find split places
                     i = check_index = 0
                     insert_par = None

--- a/tocrify/api/mets.py
+++ b/tocrify/api/mets.py
@@ -152,7 +152,11 @@ class Mets:
         """
         if self.structLink is not None:
             sm_links = self.structLink.xpath("./mets:smLink[@xlink:from=\"%s\"]" % logical.log_id, namespaces=ns)
-            first_phys_id = sm_links[0].get(XLINK + 'to')
+            try:
+                first_phys_id = sm_links[0].get(XLINK + 'to')
+            except:
+                print("Non-existing structLink for %s" % logical.log_id)
+                sys.exit(1)
             physicals = self.structMap_physical.xpath(".//mets:div[@TYPE=\"page\" and @ID=\"%s\"]" % first_phys_id, namespaces=ns)
             # direct match, i.e. same strategy for forward and backward search
             if len(physicals) > 0:


### PR DESCRIPTION
Often, headings like *I.* are not captured correctly by the OCR
resulting in matches of length 1. With the current strategy, those
may result in index errors. The rescue heading placement is now
applied in such cases.